### PR TITLE
Implement SD-JWT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ edition = "2018"
 [package.metadata.docs.rs]
 features = ["openssl"]
 
+[features]
+default = ["sd"] # TODO delete
+sd = ["openssl"] # selective disclosure requires asymmetric keys
+
 [dependencies]
 base64 = "0.13"
 crypto-common = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hmac = { version = "0.12", features = ["reset"] }
 sha2 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rand = "0.8.5"
 
 [dependencies.openssl]
 version = "0.10"

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -10,6 +10,7 @@
 //! let hs256_key: Hmac<Sha256> = Hmac::new_from_slice(b"some-secret").unwrap();
 //! ```
 
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
@@ -46,6 +47,20 @@ impl Default for AlgorithmType {
     }
 }
 
+/// The type of a hash algorithm, according to the [IANA
+/// Registry](https://www.iana.org/assignments/named-information/named-information.xhtml)
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum HashAlgorithmType {
+    #[serde(rename = "sha-256")]
+    Sha256,
+
+    #[serde(rename = "sha-384")]
+    Sha384,
+
+    #[serde(rename = "sha-512")]
+    Sha512,
+}
+
 /// An algorithm capable of signing base64 encoded header and claims strings.
 /// strings.
 pub trait SigningAlgorithm {
@@ -64,6 +79,21 @@ pub trait VerifyingAlgorithm {
         let signature_bytes = base64::decode_config(signature, base64::URL_SAFE_NO_PAD)?;
         self.verify_bytes(header, claims, &*signature_bytes)
     }
+}
+
+/// A hash algorithm
+pub trait HashAlgorithm {
+    fn hash_algorithm_type(&self) -> HashAlgorithmType;
+
+    fn hash(&self, data: impl AsRef<[u8]>) -> String;
+}
+
+/// Generate random data
+pub(crate) fn random_data(len: usize) -> Vec<u8> {
+    let mut vec = vec![0; len];
+    let mut rng = rand::thread_rng();
+    rng.fill(vec.as_mut_slice());
+    vec
 }
 
 // TODO: investigate if these AsRef impls are necessary

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,8 +28,11 @@ pub enum Error {
     #[cfg(feature = "openssl")]
     OpenSsl(openssl::error::ErrorStack),
 
+    InvalidPointer,
+    InvalidClaims,
     NoIssuerJwt,
     InvalidKeyBinding,
+    InvalidDisclosure,
 }
 
 impl fmt::Display for Error {
@@ -54,8 +57,11 @@ impl fmt::Display for Error {
             #[cfg(feature = "openssl")]
             OpenSsl(ref x) => write!(f, "{}", x),
 
+            InvalidPointer => write!(f, "Invalid JSON pointer"),
+            InvalidClaims => write!(f, "Invalid claims"),
             NoIssuerJwt => write!(f, "No issuer JWT"),
             InvalidKeyBinding => write!(f, "Invalid key binding JWT"),
+            InvalidDisclosure => write!(f, "Invalid disclosure object"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     Utf8(FromUtf8Error),
     #[cfg(feature = "openssl")]
     OpenSsl(openssl::error::ErrorStack),
+
+    NoIssuerJwt,
+    InvalidKeyBinding,
 }
 
 impl fmt::Display for Error {
@@ -50,6 +53,9 @@ impl fmt::Display for Error {
             RustCryptoMacKeyLength(ref x) => write!(f, "{}", x),
             #[cfg(feature = "openssl")]
             OpenSsl(ref x) => write!(f, "{}", x),
+
+            NoIssuerJwt => write!(f, "No issuer JWT"),
+            InvalidKeyBinding => write!(f, "Invalid key binding JWT"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     NoIssuerJwt,
     InvalidKeyBinding,
     InvalidDisclosure,
+    InvalidPresentation,
+    InvalidConfirmationKey,
 }
 
 impl fmt::Display for Error {
@@ -62,6 +64,8 @@ impl fmt::Display for Error {
             NoIssuerJwt => write!(f, "No issuer JWT"),
             InvalidKeyBinding => write!(f, "Invalid key binding JWT"),
             InvalidDisclosure => write!(f, "Invalid disclosure object"),
+            InvalidPresentation => write!(f, "Invalid presentation"),
+            InvalidConfirmationKey => write!(f, "Invalid confirmation key"),
         }
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -28,7 +28,7 @@ pub trait JoseHeader {
 
 /// Generic [JWT header](https://tools.ietf.org/html/rfc7519#page-11) with
 /// defined fields for common fields.
-#[derive(Default, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Header {
     #[serde(rename = "alg")]
     pub algorithm: AlgorithmType,
@@ -62,10 +62,12 @@ impl JoseHeader for Header {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
 pub enum HeaderType {
     #[serde(rename = "JWT")]
     JsonWebToken,
+
+    #[serde(rename = "kb+jwt")]
+    KeyBindingJwt,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,21 @@ pub struct Token<H, C, S> {
     signature: S,
 }
 
+impl<H, C, S> Clone for Token<H, C, S>
+where
+    H: Clone,
+    C: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            header: self.header.clone(),
+            claims: self.claims.clone(),
+            signature: self.signature.clone(),
+        }
+    }
+}
+
 impl<H, C, S> Token<H, C, S> {
     pub fn header(&self) -> &H {
         &self.header

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub mod algorithm;
 pub mod claims;
 pub mod error;
 pub mod header;
+pub mod sd;
 pub mod token;
 
 const SEPARATOR: &str = ".";

--- a/src/sd/mod.rs
+++ b/src/sd/mod.rs
@@ -1,0 +1,196 @@
+use crate::algorithm::{SigningAlgorithm, VerifyingAlgorithm};
+use crate::error::Error;
+use crate::header::JoseHeader;
+use crate::token::signed::SignWithKey;
+use crate::token::verified::VerifyWithKey;
+use crate::token::{Signed, Unsigned, Unverified, Verified};
+use crate::{FromBase64, ToBase64};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Disclosure;
+
+/// Representation of a structured JWT. Methods vary based on the signature
+/// type `S`.
+pub struct Token<H, C, S> {
+    issuer_jwt: crate::Token<H, C, S>,
+    disclosures: Vec<Disclosure>,
+    signature: S,
+}
+
+impl<H, C, S> Token<H, C, S> {
+    pub fn issuer_jwt(&self) -> &crate::Token<H, C, S> {
+        &self.issuer_jwt
+    }
+
+    pub fn remove_signature(self) -> Token<H, C, Unsigned> {
+        Token {
+            issuer_jwt: self.issuer_jwt.remove_signature(),
+            disclosures: self.disclosures,
+            signature: Unsigned,
+        }
+    }
+}
+
+impl<H, C> Token<H, C, Unsigned> {
+    /// Create a new unsigned token, with mutable headers and claims.
+    pub fn new(header: H, claims: C) -> Self {
+        Token {
+            issuer_jwt: crate::Token::new(header, claims),
+            disclosures: Default::default(),
+            signature: Unsigned,
+        }
+    }
+
+    pub fn issuer_jwt_mut(&mut self) -> &mut crate::Token<H, C, Unsigned> {
+        &mut self.issuer_jwt
+    }
+}
+
+impl<H, C> Default for Token<H, C, Unsigned>
+where
+    H: Default,
+    C: Default,
+{
+    fn default() -> Self {
+        Token::new(H::default(), C::default())
+    }
+}
+
+impl<'a, H, C> Token<H, C, Signed> {
+    /// Get the string representation of the token.
+    pub fn as_str(&self) -> &str {
+        &self.signature.token_string
+    }
+}
+
+impl<H, C> From<Token<H, C, Signed>> for String {
+    fn from(token: Token<H, C, Signed>) -> Self {
+        token.signature.token_string
+    }
+}
+
+impl<'a, H: FromBase64, C: FromBase64> Token<H, C, Unverified<'a>> {
+    /// Not recommended. Parse the header and claims without checking the validity of the signature.
+    pub fn parse_unverified(token_str: &str) -> Result<Token<H, C, Unverified>, Error> {
+        let mut components = token_str.split(SEPARATOR);
+        let issuer_jwt = components.next().ok_or(Error::NoIssuerJwt)?;
+
+        let mut raw_disclosures: Vec<String> = components.map(|s| s.into()).collect();
+        let last_entry = raw_disclosures.last();
+        if last_entry.is_none() || last_entry.unwrap() != "" {
+            // XXX(RLB): It seems like Option should have a more elegant flavor of the above
+            return Err(Error::InvalidKeyBinding);
+        }
+        raw_disclosures.pop();
+
+        let issuer_jwt: crate::Token<H, C, _> = crate::Token::parse_unverified(issuer_jwt)?;
+        let disclosures: Vec<Disclosure> = raw_disclosures
+            .iter()
+            .map(|d| Disclosure::from_base64(d))
+            .collect::<Result<Vec<_>, _>>()?;
+        // We only need this field for type alignment with issuer_jwt
+        let signature = Unverified {
+            header_str: &"",
+            claims_str: &"",
+            signature_str: &"",
+        };
+
+        Ok(Token {
+            issuer_jwt,
+            disclosures,
+            signature,
+        })
+    }
+}
+
+const SEPARATOR: &str = "~";
+
+impl<H, C> SignWithKey<Token<H, C, Signed>> for Token<H, C, Unsigned>
+where
+    H: ToBase64 + JoseHeader,
+    C: ToBase64,
+{
+    fn sign_with_key(self, key: &impl SigningAlgorithm) -> Result<Token<H, C, Signed>, Error> {
+        let issuer_jwt = self.issuer_jwt.sign_with_key(key)?;
+
+        let disclosures = self
+            .disclosures
+            .iter()
+            .map(|d| d.to_base64())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut parts = disclosures;
+        parts.insert(0, issuer_jwt.as_str().into()); // issuer JWT comes first
+        parts.push("".into()); // empty key binding comes last
+
+        let token_string = parts.join(SEPARATOR);
+        Ok(Token {
+            issuer_jwt: issuer_jwt,
+            disclosures: self.disclosures,
+            signature: Signed { token_string },
+        })
+    }
+}
+
+impl<'a, H: JoseHeader, C> VerifyWithKey<Token<H, C, Verified>> for Token<H, C, Unverified<'a>> {
+    fn verify_with_key(
+        self,
+        key: &impl VerifyingAlgorithm,
+    ) -> Result<Token<H, C, Verified>, Error> {
+        let issuer_jwt = self.issuer_jwt.verify_with_key(key)?;
+        Ok(Token {
+            issuer_jwt,
+            disclosures: self.disclosures,
+            signature: Verified,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::algorithm::AlgorithmType::Hs256;
+    use crate::error::Error;
+    use crate::header::Header;
+    use crate::sd::Token;
+    use crate::token::signed::SignWithKey;
+    use crate::token::verified::VerifyWithKey;
+    use crate::Claims;
+    use hmac::Hmac;
+    use hmac::Mac;
+    use sha2::Sha256;
+
+    #[test]
+    pub fn raw_data_no_disclosures() -> Result<(), Error> {
+        let raw = "eyJhbGciOiJIUzI1NiJ9.e30.XmNK3GpH3Ys_7wsYBfq4C3M6goz71I7dTgUkuIa5lyQ~";
+        let token: Token<Header, Claims, _> = Token::parse_unverified(raw)?;
+
+        assert_eq!(token.issuer_jwt().header().algorithm, Hs256);
+
+        let verifier: Hmac<Sha256> = Hmac::new_from_slice(b"secret")?;
+        assert!(token.verify_with_key(&verifier).is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn roundtrip_no_disclosures() -> Result<(), Error> {
+        let token: Token<Header, Claims, _> = Default::default();
+        let key: Hmac<Sha256> = Hmac::new_from_slice(b"secret")?;
+        let signed_token = token.sign_with_key(&key)?;
+        let signed_token_str = signed_token.as_str();
+
+        let recreated_token: Token<Header, Claims, _> = Token::parse_unverified(signed_token_str)?;
+
+        assert_eq!(
+            signed_token.issuer_jwt().header(),
+            recreated_token.issuer_jwt().header()
+        );
+        assert_eq!(
+            signed_token.issuer_jwt().claims(),
+            recreated_token.issuer_jwt().claims()
+        );
+        recreated_token.verify_with_key(&key)?;
+        Ok(())
+    }
+}

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -3,14 +3,18 @@
 pub mod signed;
 pub mod verified;
 
+#[derive(Clone)]
 pub struct Unsigned;
 
+#[derive(Clone)]
 pub struct Signed {
     pub token_string: String,
 }
 
+#[derive(Clone)]
 pub struct Verified;
 
+#[derive(Clone)]
 pub struct Unverified<'a> {
     pub header_str: &'a str,
     pub claims_str: &'a str,


### PR DESCRIPTION
This is a first-draft implementation of SD-JWT on top of the `jwt` crate.  I've done this mainly as a learning exercise, working through the conceptual structure of SD-JWT with the rigor of Rust as a guide.  But it may be useful to merge eventually.

The core of the new functionality is all in `src/sd/mod.rs`.  (TODO split into some modules)  We define Token and Presentation structs there that have a similar life-cycle to the top-level Token object.  In addition to the serialization changes, the major additions are:

* `redact()` and `unredact()` methods on an `Unsigned` Token, which make certain fields in the token claims selectively disclosable
* A `reveal()` method on a `Verified` Token, which discloses all of the selectively disclosable fields
* `forget()` and `forget_all()` methods on Presentation, which make some fields non-disclosable

Obviously, there's some non-trivial JSON manipulation here, which we accomplish by making a lot of use of `serde_json::Value`.  In particular, the `Redactable` trait implementation for `Value` encodes most of the interesting JSON manipulation algorithms.

Testing is in pretty good shape.  Not super exhaustive, but verifies most of the happy paths.  It would be good to incorporate some of the example cases from the document as tests.